### PR TITLE
Fix CMake project declaration order (unit1)

### DIFF
--- a/labs/cw1/CMakeLists.txt
+++ b/labs/cw1/CMakeLists.txt
@@ -1,5 +1,5 @@
-project(set10108-cw1)
 cmake_minimum_required(VERSION 3.17)
+project(set10108-cw1)
 set(CMAKE_CXX_STANDARD 17)
 
 include_directories(../contrib)

--- a/labs/cw2/CMakeLists.txt
+++ b/labs/cw2/CMakeLists.txt
@@ -1,5 +1,5 @@
-project(set10108-cw2)
 cmake_minimum_required(VERSION 3.17)
+project(set10108-cw2)
 set(CMAKE_CXX_STANDARD 17)
 
 include_directories(../contrib)

--- a/labs/unit1/CMakeLists.txt
+++ b/labs/unit1/CMakeLists.txt
@@ -1,5 +1,5 @@
-project(set10108-unit1)
 cmake_minimum_required(VERSION 3.17)
+project(set10108-unit1)
 set(CMAKE_CXX_STANDARD 17)
 include_directories(../contrib)
 

--- a/labs/unit2/CMakeLists.txt
+++ b/labs/unit2/CMakeLists.txt
@@ -1,5 +1,5 @@
-project(set10108-unit2 LANGUAGES CXX CUDA)
 cmake_minimum_required(VERSION 3.17)
+project(set10108-unit2 LANGUAGES CXX CUDA)
 set(CMAKE_CXX_STANDARD 17)
 include_directories(../contrib)
  

--- a/labs/unit3/CMakeLists.txt
+++ b/labs/unit3/CMakeLists.txt
@@ -1,5 +1,5 @@
-project(set10108-unit3 LANGUAGES CXX CUDA)
 cmake_minimum_required(VERSION 3.17)
+project(set10108-unit3 LANGUAGES CXX CUDA)
 set(CMAKE_CXX_STANDARD 17)
 include_directories(../contrib)
  

--- a/labs/unit4/CMakeLists.txt
+++ b/labs/unit4/CMakeLists.txt
@@ -1,5 +1,5 @@
-project(set10108-unit4)
 cmake_minimum_required(VERSION 3.17)
+project(set10108-unit4)
 set(CMAKE_CXX_STANDARD 17)
 include_directories(../contrib)
 

--- a/labs/unit5/CMakeLists.txt
+++ b/labs/unit5/CMakeLists.txt
@@ -1,5 +1,5 @@
-project(set10108-unit5 LANGUAGES CXX CUDA)
 cmake_minimum_required(VERSION 3.17)
+project(set10108-unit5 LANGUAGES CXX CUDA)
 set(CMAKE_CXX_STANDARD 17)
 include_directories(../contrib)
 

--- a/labs/unit6/CMakeLists.txt
+++ b/labs/unit6/CMakeLists.txt
@@ -1,5 +1,5 @@
-project(set10108-unit6)
 cmake_minimum_required(VERSION 3.17)
+project(set10108-unit6)
 set(CMAKE_CXX_STANDARD 17)
 include_directories(../contrib)
 

--- a/labs/unit7/CMakeLists.txt
+++ b/labs/unit7/CMakeLists.txt
@@ -1,5 +1,5 @@
-project(set10108-unit7)
 cmake_minimum_required(VERSION 3.17)
+project(set10108-unit7)
 set(CMAKE_CXX_STANDARD 17)
 include_directories(../contrib)
 

--- a/labs/unit8a/CMakeLists.txt
+++ b/labs/unit8a/CMakeLists.txt
@@ -1,5 +1,5 @@
-project(set10108-unit8a)
 cmake_minimum_required(VERSION 3.17)
+project(set10108-unit8a)
 set(CMAKE_CXX_STANDARD 17)
 include_directories(../contrib)
 

--- a/labs/unit8b/CMakeLists.txt
+++ b/labs/unit8b/CMakeLists.txt
@@ -1,5 +1,5 @@
-project(set10108-unit8b)
 cmake_minimum_required(VERSION 3.17)
+project(set10108-unit8b)
 set(CMAKE_CXX_STANDARD 17)
 include_directories(../contrib)
 


### PR DESCRIPTION
# Fix CMake warning: call cmake_minimum_required() before project()

## Summary
Fixes CMake warning by reordering `project()` declaration after `cmake_minimum_required()` call.

## Changes
- Moved `project(set10108-unit1)` below `cmake_minimum_required()` 
- Resolves: "cmake_minimum_required() should be called prior to this top-level project() call"

## Type of Change
- [x] Bug fix (fixes CMake configuration warning)

> [!NOTE]  
>This same warning exists in other units and should be fixed consistently across the project.

<img width="1465" height="232" alt="Screenshot 2025-09-18 124709" src="https://github.com/user-attachments/assets/1c3f4d73-2999-4f22-bfbe-cf02874eccfd" />
